### PR TITLE
Added option for png image

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI, Response, Query
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from module import generator, util
 from typing import Optional
+import io
 
 app = FastAPI()
 
@@ -16,7 +17,16 @@ def root():
 def api(
     data: str = Query(min_length=1), 
     style: Optional[str] = "square", 
+    formate: Optional[str] = "svg",
+    version: Optional[int] = None,
+    box_size: Optional[int] = None,
+    border: Optional[int] = None,
     bg_color: Optional[str] = None, 
     fill_color: Optional[str] = None
 ):
-    return Response(generator.get_svg_string(data, style, bg_color, fill_color), media_type="image/svg+xml")
+    if formate == "png":
+        image_bytes = generator.get_png_bytes(data, style, bg_color, fill_color, version, box_size, border)
+        buffer = io.BytesIO(image_bytes)
+        return StreamingResponse(buffer, media_type="image/png")
+    else:
+        return Response(generator.get_svg_string(data, style, bg_color, fill_color), media_type="image/svg+xml")

--- a/module/generator.py
+++ b/module/generator.py
@@ -1,8 +1,9 @@
 import qrcode
+import io
 from qrcode.image.svg import SvgPathImage
 from qrcode.image.styles.moduledrawers.svg import SvgPathCircleDrawer
 from qrcode.image.styles.moduledrawers.svg import SvgPathSquareDrawer
-
+from PIL import Image, ImageDraw
 
 def get_svg_string(data: str, style: str, bg_color, fill_color) -> str:
     # create drawer either square or circle
@@ -30,3 +31,47 @@ def get_svg_string(data: str, style: str, bg_color, fill_color) -> str:
         result = result.replace('fill="#000000"', f'fill="{fill_color}"')
 
     return result[2:-1]
+
+def get_png_bytes(data: str, style: str, bg_color, fill_color, version=None, box_size=10, border=4) -> bytes:
+    qr = qrcode.QRCode(
+        version=version,
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=box_size,
+        border=border,
+    )
+
+    qr.add_data(data)
+    qr.make(fit=True)
+
+    # create image with circle style
+    if style == "circle":
+        img = qr.make_image(fill_color="white", back_color="white").convert('RGBA')
+        circle_img = Image.new('RGBA', img.size, (255, 255, 255, 0))
+        draw = ImageDraw.Draw(circle_img)
+
+        for row in range(qr.modules_count):
+            for col in range(qr.modules_count):
+                if qr.modules[row][col]:
+                    x0 = col * box_size + border * box_size
+                    y0 = row * box_size + border * box_size
+                    x1 = x0 + box_size
+                    y1 = y0 + box_size
+                    draw.ellipse([x0, y0, x1, y1], fill=fill_color)
+
+        img = Image.alpha_composite(img, circle_img)
+        if bg_color:
+            background = Image.new('RGBA', img.size, bg_color)
+            img = Image.alpha_composite(background, img)
+
+        # convert image to bytes
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        buffer.seek(0)
+        return buffer.getvalue()
+
+    else:
+        img = qr.make_image(fill_color=fill_color, back_color=bg_color)
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        buffer.seek(0)
+        return buffer.getvalue()

--- a/module/util.py
+++ b/module/util.py
@@ -40,6 +40,48 @@ def get_html_form():
                         </select>
                     </div>
                     <div class="mb-3">
+                        <label for="formate" class="form-label">Format</label>
+                        <select class="form-select" name="formate" id="formate" onchange="togglePngOptions()">
+                            <option selected value="svg">SVG</option>
+                            <option value="png">PNG</option>
+                        </select>
+                    </div>
+                    <div id="png-options" style="display: none;">
+                        <div class="mb-3">
+                            <label for="version" class="form-label">Version</label>
+                            <select class="form-select" name="version" id="version">
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                                <option value="5">5</option>
+                                <option value="6">6</option>
+                                <option value="7">7</option>
+                                <option value="8">8</option>
+                                <option value="9">9</option>
+                                <option value="10">10</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="box_size" class="form-label">Box Size: <span id="box_size_value">10</span></label>
+                            <input type="range" class="form-range" id="box_size" name="box_size" min="1" max="100" value="10" oninput="updateBoxSizeValue(this.value)">
+                            <div class="d-flex justify-content-between">
+                                <span>1</span>
+                                <span>50</span>
+                                <span>100</span>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="border" class="form-label">Border Size: <span id="border_value">4</span></label>
+                            <input type="range" class="form-range" id="border" name="border" min="0" max="50" value="4" oninput="updateBorderSizeValue(this.value)">
+                            <div class="d-flex justify-content-between">
+                                <span>1</span>
+                                <span>4</span>
+                                <span>50</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mb-3">
                         <label for="bg-color" class="form-label">Background Color</label>
                         <input 
                             class="form-control" 
@@ -67,6 +109,23 @@ def get_html_form():
             integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm"
             crossorigin="anonymous"
             ></script>
+            <script>
+                function togglePngOptions() {
+                    var formatSelect = document.getElementById("formate");
+                    var pngOptions = document.getElementById("png-options");
+                    if (formatSelect.value === "png") {
+                        pngOptions.style.display = "block";
+                    } else {
+                        pngOptions.style.display = "none";
+                    }
+                }
+                function updateBoxSizeValue(value) {
+                    document.getElementById("box_size_value").innerText = value;
+                }
+                function updateBorderSizeValue(value) {
+                    document.getElementById("border_value").innerText = value;
+                }
+            </script>
         </body>
         </html>
     """


### PR DESCRIPTION
Description:
This pull request introduces a new feature to the QR code generation repository by implementing the ability to generate QR codes in PNG format. This enhancement expands the usability of the repository by providing users with the flexibility to choose between SVG and PNG formats for their generated QR codes.

<img width="302" alt="image" src="https://github.com/putuwaw/qr-generator/assets/57295425/42164ca6-e694-4da4-8139-68f4188dc6d4">